### PR TITLE
Add python2-six build dependency

### DIFF
--- a/mos/archlinux_pkgbuild/mos-latest/PKGBUILD
+++ b/mos/archlinux_pkgbuild/mos-latest/PKGBUILD
@@ -11,6 +11,7 @@ makedepends=(
     'git'
     'python2'
     'python2-gitpython'
+    'python2-six'
     'govendor'
     'jshon'
 )


### PR DESCRIPTION
pkgver() fails to output a package version without this python2 module.